### PR TITLE
hotfix: EventBridge Rule Naming for Production Environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,13 @@ lerna-debug.log*
 .env.production.local
 .env.production
 .env.local
+.env.production
+
+# Lambda files
+lambda/
+
+# Otto SDK
+otto-sdk/
 
 # temp directory
 .temp

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@aws-sdk/client-ecs": "^3.894.0",
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.895.0",
     "@aws-sdk/client-eventbridge": "^3.894.0",
+    "@aws-sdk/client-lambda": "^3.895.0",
     "@aws-sdk/client-route-53": "^3.894.0",
     "@aws-sdk/client-s3": "^3.893.0",
     "@aws-sdk/client-sts": "^3.894.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@aws-sdk/client-eventbridge':
         specifier: ^3.894.0
         version: 3.894.0
+      '@aws-sdk/client-lambda':
+        specifier: ^3.895.0
+        version: 3.895.0
       '@aws-sdk/client-route-53':
         specifier: ^3.894.0
         version: 3.894.0
@@ -304,6 +307,10 @@ packages:
 
   '@aws-sdk/client-eventbridge@3.894.0':
     resolution: {integrity: sha512-HJcd2Xk0QJ9WzMlhwcIVS7G+E0pmqV814QfgBceZE3pTOIGxsfkZFwHnUZ/Cg0S/uB4nP+ADVSpVoZd4gD6BXQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/client-lambda@3.895.0':
+    resolution: {integrity: sha512-cuc3agKUr4K8B7bEftFeEdHEMnnIVoXuS7hBmLtRx4Sza394+l+0WV5/xnlz1Bd35NGyC/J5ebp1RjqxXzk7IA==}
     engines: {node: '>=18.0.0'}
 
   '@aws-sdk/client-route-53@3.894.0':
@@ -5197,6 +5204,55 @@ snapshots:
       '@smithy/util-middleware': 4.1.1
       '@smithy/util-retry': 4.1.2
       '@smithy/util-utf8': 4.1.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-lambda@3.895.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.894.0
+      '@aws-sdk/credential-provider-node': 3.895.0
+      '@aws-sdk/middleware-host-header': 3.893.0
+      '@aws-sdk/middleware-logger': 3.893.0
+      '@aws-sdk/middleware-recursion-detection': 3.893.0
+      '@aws-sdk/middleware-user-agent': 3.895.0
+      '@aws-sdk/region-config-resolver': 3.893.0
+      '@aws-sdk/types': 3.893.0
+      '@aws-sdk/util-endpoints': 3.895.0
+      '@aws-sdk/util-user-agent-browser': 3.893.0
+      '@aws-sdk/util-user-agent-node': 3.895.0
+      '@smithy/config-resolver': 4.2.2
+      '@smithy/core': 3.11.1
+      '@smithy/eventstream-serde-browser': 4.1.1
+      '@smithy/eventstream-serde-config-resolver': 4.2.1
+      '@smithy/eventstream-serde-node': 4.1.1
+      '@smithy/fetch-http-handler': 5.2.1
+      '@smithy/hash-node': 4.1.1
+      '@smithy/invalid-dependency': 4.1.1
+      '@smithy/middleware-content-length': 4.1.1
+      '@smithy/middleware-endpoint': 4.2.3
+      '@smithy/middleware-retry': 4.2.4
+      '@smithy/middleware-serde': 4.1.1
+      '@smithy/middleware-stack': 4.1.1
+      '@smithy/node-config-provider': 4.2.2
+      '@smithy/node-http-handler': 4.2.1
+      '@smithy/protocol-http': 5.2.1
+      '@smithy/smithy-client': 4.6.3
+      '@smithy/types': 4.5.0
+      '@smithy/url-parser': 4.1.1
+      '@smithy/util-base64': 4.1.0
+      '@smithy/util-body-length-browser': 4.1.0
+      '@smithy/util-body-length-node': 4.1.0
+      '@smithy/util-defaults-mode-browser': 4.1.3
+      '@smithy/util-defaults-mode-node': 4.1.3
+      '@smithy/util-endpoints': 3.1.2
+      '@smithy/util-middleware': 4.1.1
+      '@smithy/util-retry': 4.1.2
+      '@smithy/util-stream': 4.3.2
+      '@smithy/util-utf8': 4.1.0
+      '@smithy/util-waiter': 4.1.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt

--- a/src/codebuild/eventbridge.service.ts
+++ b/src/codebuild/eventbridge.service.ts
@@ -31,11 +31,12 @@ export class EventBridgeService {
     codebuildProjectName: string,
   ): Promise<string> {
     // EventBridge Rule 이름은 64자 제한
-    // codebuildProjectName이 otto-development-{uuid}-build 형태
+    // codebuildProjectName이 otto-development-{uuid}-build 또는 otto-production-{uuid}-build 형태
     // UUID 부분만 추출하여 사용
     const parts = codebuildProjectName.split('-');
     const projectId = parts[parts.length - 2]; // UUID 부분 추출
-    const ruleName = `otto-dev-${projectId}`;
+    const environment = process.env.NODE_ENV === 'production' ? 'prod' : 'dev';
+    const ruleName = `otto-${environment}-${projectId}`;
 
     try {
       // 1. EventBridge Rule 생성
@@ -105,7 +106,8 @@ export class EventBridgeService {
     // 생성 시와 동일한 로직으로 Rule 이름 생성
     const parts = codebuildProjectName.split('-');
     const projectId = parts[parts.length - 2];
-    const ruleName = `otto-dev-${projectId}`;
+    const environment = process.env.NODE_ENV === 'production' ? 'prod' : 'dev';
+    const ruleName = `otto-${environment}-${projectId}`;
 
     try {
       // 1. 먼저 타겟 제거

--- a/src/codebuild/eventbridge.service.ts
+++ b/src/codebuild/eventbridge.service.ts
@@ -6,21 +6,34 @@ import {
   RemoveTargetsCommand,
   DeleteRuleCommand,
 } from '@aws-sdk/client-eventbridge';
+import {
+  LambdaClient,
+  AddPermissionCommand,
+  RemovePermissionCommand,
+} from '@aws-sdk/client-lambda';
 
 @Injectable()
 export class EventBridgeService {
   private readonly logger = new Logger(EventBridgeService.name);
   private readonly client: EventBridgeClient;
+  private readonly lambdaClient: LambdaClient;
+  private readonly region: string;
 
   constructor() {
-    const region = process.env.AWS_REGION || 'ap-northeast-2';
+    this.region = process.env.AWS_REGION || 'ap-northeast-2';
+    const credentials = {
+      accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
+    };
 
     this.client = new EventBridgeClient({
-      region,
-      credentials: {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
-      },
+      region: this.region,
+      credentials,
+    });
+
+    this.lambdaClient = new LambdaClient({
+      region: this.region,
+      credentials,
     });
   }
 
@@ -87,6 +100,38 @@ export class EventBridgeService {
       );
 
       this.logger.log(`Lambda target added to rule: ${ruleName}`);
+
+      // 3. Lambda에 EventBridge 호출 권한 추가
+      const statementId = `${ruleName}-permission`;
+
+      try {
+        await this.lambdaClient.send(
+          new AddPermissionCommand({
+            FunctionName: lambdaArn.split(':').pop(), // Lambda 함수 이름 추출
+            StatementId: statementId,
+            Action: 'lambda:InvokeFunction',
+            Principal: 'events.amazonaws.com',
+            SourceArn: `arn:aws:events:${this.region}:${lambdaArn.split(':')[4]}:rule/${ruleName}`,
+          }),
+        );
+        this.logger.log(`Lambda permission added for rule: ${ruleName}`);
+      } catch (permissionError: unknown) {
+        const errorObj = permissionError as { name?: string; message?: string };
+        // 이미 존재하는 권한은 무시
+        if (errorObj.name !== 'ResourceConflictException') {
+          this.logger.error(
+            `Failed to add Lambda permission: ${errorObj.message || 'Unknown error'}`,
+          );
+          // Permission 추가 실패 시 Rule과 Target 롤백
+          await this.deleteRuleByName(ruleName);
+          throw new Error(
+            `Lambda 권한 추가 실패: ${errorObj.message || 'Unknown error'}`,
+          );
+        }
+        this.logger.log(
+          `Lambda permission already exists for rule: ${ruleName}`,
+        );
+      }
       return ruleName;
     } catch (error: unknown) {
       const errorObj = error as { message?: string };
@@ -129,7 +174,33 @@ export class EventBridgeService {
         }
       }
 
-      // 2. Rule 삭제
+      // 2. Lambda 권한 제거
+      const lambdaArn = process.env.OTTO_LAMBDA_ARN;
+      if (lambdaArn) {
+        const statementId = `${ruleName}-permission`;
+        try {
+          await this.lambdaClient.send(
+            new RemovePermissionCommand({
+              FunctionName: lambdaArn.split(':').pop(), // Lambda 함수 이름 추출
+              StatementId: statementId,
+            }),
+          );
+          this.logger.log(`Lambda permission removed for rule: ${ruleName}`);
+        } catch (permissionError: unknown) {
+          const errorObj = permissionError as {
+            name?: string;
+            message?: string;
+          };
+          // 권한이 없는 경우는 무시
+          if (errorObj.name !== 'ResourceNotFoundException') {
+            this.logger.warn(
+              `Failed to remove Lambda permission: ${errorObj.message || 'Unknown error'}`,
+            );
+          }
+        }
+      }
+
+      // 3. Rule 삭제
       await this.client.send(
         new DeleteRuleCommand({
           Name: ruleName,
@@ -172,7 +243,33 @@ export class EventBridgeService {
         }
       }
 
-      // 2. Rule 삭제
+      // 2. Lambda 권한 제거
+      const lambdaArn = process.env.OTTO_LAMBDA_ARN;
+      if (lambdaArn) {
+        const statementId = `${ruleName}-permission`;
+        try {
+          await this.lambdaClient.send(
+            new RemovePermissionCommand({
+              FunctionName: lambdaArn.split(':').pop(), // Lambda 함수 이름 추출
+              StatementId: statementId,
+            }),
+          );
+          this.logger.log(`Lambda permission removed for rule: ${ruleName}`);
+        } catch (permissionError: unknown) {
+          const errorObj = permissionError as {
+            name?: string;
+            message?: string;
+          };
+          // 권한이 없는 경우는 무시
+          if (errorObj.name !== 'ResourceNotFoundException') {
+            this.logger.warn(
+              `Failed to remove Lambda permission: ${errorObj.message || 'Unknown error'}`,
+            );
+          }
+        }
+      }
+
+      // 3. Rule 삭제
       await this.client.send(
         new DeleteRuleCommand({
           Name: ruleName,

--- a/src/logs/logs.gateway.spec.ts
+++ b/src/logs/logs.gateway.spec.ts
@@ -6,6 +6,8 @@ import { LogsService } from './logs.service';
 import { LogBufferService } from './services/log-buffer/log-buffer.service';
 import { JwtService } from '../auth/jwt.service';
 import { Socket, Server } from 'socket.io';
+import { Execution } from '../database/entities/execution.entity';
+import { LogLevel } from '../database/entities/execution-log.entity';
 
 describe('LogsGateway', () => {
   let gateway: LogsGateway;
@@ -171,9 +173,9 @@ describe('LogsGateway', () => {
           executionId: 'test-execution-id',
           timestamp: new Date(),
           message: 'historical log',
-          level: 'info' as const,
+          level: LogLevel.INFO,
           createdAt: new Date(),
-          execution: {} as unknown,
+          execution: {} as Execution,
         },
       ];
 


### PR DESCRIPTION
## 요약
- EventBridge Rule 이름 생성 로직이 환경에 관계없이 항상 `otto-dev-` 접두어를 사용하는 문제 수정  
- `NODE_ENV`에 따라 동적으로 접두어를 설정하도록 변경  

## 주요 변경 사항
### EventBridge Service 수정
- `eventbridge.service.ts`의 `createCodeBuildEventRule` 메소드 수정  
  - 프로덕션 환경: `otto-prod-{projectId}` 형식 사용  
  - 개발 환경: `otto-dev-{projectId}` 형식 사용  
- `deleteCodeBuildEventRule` 메소드에도 동일한 로직 적용

### Lambda Permission 자동 관리 기능 추가
- EventBridge Rule 생성 시 Lambda 호출 권한 자동 추가  
- EventBridge Rule 삭제 시 Lambda 권한 자동 제거 

### 테스트 파일 타입 오류 수정
- `logs.gateway.spec.ts`의 import 경로 수정  
- `Execution` 엔티티 및 `LogLevel` enum 올바른 경로로 import  
- `unknown` 타입을 적절한 타입으로 변경  


## 테스트 사항
- [x] 코드 빌드 성공 확인  
- [x] 개발 환경에서 EventBridge Rule 생성 테스트  
- [ ] 프로덕션 환경 배포 후 EventBridge Rule 생성 확인  