### PR TITLE
fix: EventBridge production rule naming

### DIFF
--- a/src/codebuild/eventbridge.service.ts
+++ b/src/codebuild/eventbridge.service.ts
@@ -105,6 +105,19 @@ export class EventBridgeService {
       const statementId = `${ruleName}-permission`;
 
       try {
+        // 먼저 기존 권한 제거 시도 (중복 방지)
+        try {
+          await this.lambdaClient.send(
+            new RemovePermissionCommand({
+              FunctionName: lambdaArn.split(':').pop(),
+              StatementId: statementId,
+            }),
+          );
+          this.logger.log(`Removed existing permission: ${statementId}`);
+        } catch {
+          // 권한이 없으면 무시
+        }
+
         await this.lambdaClient.send(
           new AddPermissionCommand({
             FunctionName: lambdaArn.split(':').pop(), // Lambda 함수 이름 추출

--- a/src/logs/logs.gateway.ts
+++ b/src/logs/logs.gateway.ts
@@ -17,11 +17,7 @@ import { LogBufferService } from './services/log-buffer/log-buffer.service';
   cors: {
     origin:
       process.env.NODE_ENV === 'production'
-        ? [
-            'https://otto.codecat.shop',
-            'https://codecat-otto.shop',
-            'https://www.codecat-otto.shop',
-          ]
+        ? ['https://codecat-otto.shop', 'https://www.codecat-otto.shop']
         : [
             process.env.FRONTEND_URL || 'http://localhost:5173',
             'http://localhost:5173',
@@ -31,6 +27,9 @@ import { LogBufferService } from './services/log-buffer/log-buffer.service';
     credentials: true,
   },
   namespace: '/logs',
+  transports: ['websocket', 'polling'],
+  pingTimeout: 60000,
+  pingInterval: 25000,
 })
 export class LogsGateway implements OnGatewayConnection, OnGatewayDisconnect {
   @WebSocketServer()

--- a/src/logs/logs.gateway.ts
+++ b/src/logs/logs.gateway.ts
@@ -17,7 +17,11 @@ import { LogBufferService } from './services/log-buffer/log-buffer.service';
   cors: {
     origin:
       process.env.NODE_ENV === 'production'
-        ? ['https://codecat-otto.shop', 'https://www.codecat-otto.shop']
+        ? [
+            'https://otto.codecat.shop',
+            'https://codecat-otto.shop',
+            'https://www.codecat-otto.shop',
+          ]
         : [
             process.env.FRONTEND_URL || 'http://localhost:5173',
             'http://localhost:5173',


### PR DESCRIPTION
EventBridge Rule 이름을 환경별로 구분하도록 수정
- 프로덕션: `otto-prod-{projectId}` 형식
- 개발: `otto-dev-{projectId}` 형식
- NODE_ENV 값에 따라 동적으로 접두어 생성