### PR TITLE
fix: database column name error in log recovery

### DIFF
--- a/src/logs/logs.controller.ts
+++ b/src/logs/logs.controller.ts
@@ -260,6 +260,33 @@ export class LogsController {
     };
   }
 
+  @Post('executions/recover-missing-logs')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Manually trigger recovery of missing logs' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Returns recovery result',
+  })
+  async recoverMissingLogs(): Promise<{
+    success: boolean;
+    message: string;
+    error?: string;
+  }> {
+    try {
+      await this.logsService.recoverMissingLogs();
+      return {
+        success: true,
+        message: 'Log recovery completed successfully',
+      };
+    } catch (error) {
+      return {
+        success: false,
+        message: 'Log recovery failed',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  }
+
   @Get('executions/:id/archive-url')
   @ApiOperation({ summary: 'Get S3 archive URL for completed execution' })
   @ApiParam({ name: 'id', description: 'Execution ID' })

--- a/src/logs/logs.service.ts
+++ b/src/logs/logs.service.ts
@@ -522,7 +522,7 @@ export class LogsService {
         .where('execution.status = :status', {
           status: ExecutionStatus.SUCCESS,
         })
-        .andWhere('execution.createdAt >= :oneDayAgo', { oneDayAgo })
+        .andWhere('execution.started_at >= :oneDayAgo', { oneDayAgo })
         .getMany();
 
       let recoveredCount = 0;


### PR DESCRIPTION
## 주요 변경 사항
- Execution 엔티티의 잘못된 컬럼명 참조 수정 (`createdAt` → `started_at`)
- 로그 복구 기능 수동 테스트용 엔드포인트 추가

## 해결된 문제
- `QueryFailedError: column execution.createdat does not exist` 에러 수정

## 테스트 방법
```bash
curl -X POST http://localhost:4000/logs/executions/recover-missing-logs \
  -H "Authorization: Bearer {TOKEN}"